### PR TITLE
Handle the case where the last program in a chain has more than one cell

### DIFF
--- a/pyparsedvd/vts_ifo/vts_pgci.py
+++ b/pyparsedvd/vts_ifo/vts_pgci.py
@@ -90,6 +90,9 @@ class VTSPGCI(Sector):
             self.ifo.seek(offset + PGCOffset.NB_PROGRAMS, os.SEEK_SET)
             nb_program, = self._unpack_byte(1)
 
+            self.ifo.seek(offset + PGCOffset.NB_CELLS, os.SEEK_SET)
+            nb_cells, = self._unpack_byte(1)
+
             self.ifo.seek(offset + PGCOffset.PLAYBACK_TIME, os.SEEK_SET)
             duration = self._get_timespan(self.ifo.read(4))
 
@@ -115,6 +118,8 @@ class VTSPGCI(Sector):
                     self.ifo.seek(offset + program_map_offset + program + 0x01, os.SEEK_SET)
                     exit_cell, = self._unpack_byte(1)
                     exit_cell -= 1
+                else:
+                    exit_cell = nb_cells
 
 
                 for cell in range(entry_cell, exit_cell + 1):


### PR DESCRIPTION
Without these changes the last program in a chain would only include one cell in the `playback_times` list because there is no next `entry_cell` to consider. However the PGC header includes the number of cells, so this change reads that and simply includes all of the remaining cells in the last program.

See example PGC from commercial DVD:
![image](https://user-images.githubusercontent.com/3258334/226194776-dd3f9a95-768f-4749-9a7d-675891533be2.png)
